### PR TITLE
Downgrade Dart sdk version to 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+- Remove offensive vocabularies in Korean / Noun / Animal and Korean / Adjective / Emotion
+- Downgrade min Dart sdk version from 2.18.2 to [2.12.0](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2120---2021-03-03)
+
 ## 0.0.1
 
 - Initial version

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: random_nickname
 description: a Dart package that provides random nickname with various languages.
-version: 0.0.1
+version: 0.0.2
 repository: https://github.com/Holder-inc/random_nickname
 issue_tracker: https://github.com/Holder-inc/random_nickname/issues
 
 environment:
-  sdk: '>=2.18.2 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. (what, how, where...) -->
## Summary of the Pull Request
Currently, this package does not use up-to-dated features from 2.18.2.
In order to support more cases, this PR suggest to downgrade min Dart sdk version to 2.12.0.
It's 2.12.0 because this version is the first version where null safe rule is selected as default.

<!-- Any references that worth mentioning --> 
## References
- https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2120---2021-03-03

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Passed `dart format`
* [x] Passed `dart analyze --fatal-infos`
* [x] Tests added/passed

<!-- Provide a more detailed description of the PR and additional comments if you have-->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. -->
## Validation Steps Performed
Example runs without any error.